### PR TITLE
Made reset/initial zoom smaller.

### DIFF
--- a/pairviewer.js
+++ b/pairviewer.js
@@ -810,7 +810,7 @@ function zoomed() {
 
 function resetZoom() {
   var scale = zoom.scale();
-  var initial = 3;
+  var initial = 2;
   var defaultScale = Math.min(initial*fixedHeight,initial*fixedWidth);
 
   d3.transition().duration(150).tween("zoom", function () {


### PR DESCRIPTION
Made reset/initial zoom smaller, should fit the screen pretty nicely.
![screen shot 2017-12-29 at 10 07 28 pm](https://user-images.githubusercontent.com/13565154/34451735-b1059364-ece4-11e7-94b3-a395fda1d5f4.png)
