### PR TITLE
Fix long flyers fading

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Colin Pillsbury, Spring 2017, cpillsb1@swarthmore.edu
 @coler706
 Jonathan Washington, @jonorthwash, jonathan.n.washington@gmail.com
 @diogoscf
+@albertonl

--- a/pairviewer.js
+++ b/pairviewer.js
@@ -1252,9 +1252,9 @@ function fadeAtEdge(d) {
   }
 
   let centerPos = proj.invert([fixedWidth / 2, fixedHeight / 2]),
-  start,
-  end,
-  distancePair; // distance of a flyer (in radians)
+    start,
+    end,
+    distancePair; // distance of a flyer (in radians)
 
   // function is called on 2 different data structures..
   if (d.source) {

--- a/pairviewer.js
+++ b/pairviewer.js
@@ -38,7 +38,7 @@ let swoosh = d3
   .line()
   .x(d => d[0])
   .y(d => d[1])
-  .curve(d3.curveCardinal.tension(-1));
+  .curve(d3.curveCardinal.tension(-1.5));
 
 let links = [],
   arcLines = [];

--- a/pairviewer.js
+++ b/pairviewer.js
@@ -1287,17 +1287,27 @@ function fadeAtEdge(d) {
     atBack = false;                                 // boolean representing if the flyer is at the back of the globe
 
     diffAvgCenterLongitude = avgLongitudeStartEnd - centerPos[0];
-    if (diffAvgCenterLongitude > 180) diffAvgCenterLongitude = -180 + (diffAvgCenterLongitude-180);
-    else if (diffAvgCenterLongitude < 180) diffAvgCenterLongitude = 180 - (diffAvgCenterLongitude+180);
+    if (diffAvgCenterLongitude > 180) {
+      diffAvgCenterLongitude = -180 + (diffAvgCenterLongitude-180);
+    }
+    else if (diffAvgCenterLongitude < -180) {
+      diffAvgCenterLongitude = 180 - (diffAvgCenterLongitude+180);
+    }
 
     diffAvgCenterLatitude = avgLatitudeStartEnd - centerPos[1];
-    if (diffAvgCenterLatitude > 180) diffAvgCenterLatitude = -180 + (diffAvgCenterLatitude-180);
-    else if (diffAvgCenterLatitude < 180) diffAvgCenterLatitude = 180 - (diffAvgCenterLatitude+180);
+    if (diffAvgCenterLatitude > 180) {
+      diffAvgCenterLatitude = -180 + (diffAvgCenterLatitude-180);
+    }
+    else if (diffAvgCenterLatitude < -180) {
+      diffAvgCenterLatitude = 180 - (diffAvgCenterLatitude+180);
+    }
 
-    if (diffAvgCenterLongitude <= -130 && diffAvgCenterLongitude >= -180) atBack = true;
-    else if(diffAvgCenterLongitude >= 130 && diffAvgCenterLongitude <=180) atBack = true;
-    else if(diffAvgCenterLatitude <= -130 && diffAvgCenterLatitude >= -180) atBack = true;
-    else if(diffAvgCenterLatitude >= 130 && diffAvgCenterLatitude <= 180) atBack = true;
+    if((diffAvgCenterLongitude <= -130 && diffAvgCenterLongitude >= -180) ||
+      (diffAvgCenterLongitude >= 130 && diffAvgCenterLongitude <=180) ||
+      (diffAvgCenterLatitude <= -130 && diffAvgCenterLatitude >= -180) ||
+      (diffAvgCenterLatitude >= 130 && diffAvgCenterLatitude <=180)) {
+      atBack = true;
+    }
 
     if(atBack){
       svg.select('.flyer').attr("opacity", 0);

--- a/pairviewer.js
+++ b/pairviewer.js
@@ -1302,10 +1302,10 @@ function fadeAtEdge(d) {
       diffAvgCenterLatitude = 180 - (diffAvgCenterLatitude+180);
     }
 
-    if((diffAvgCenterLongitude <= -130 && diffAvgCenterLongitude >= -180) ||
-      (diffAvgCenterLongitude >= 130 && diffAvgCenterLongitude <=180) ||
-      (diffAvgCenterLatitude <= -130 && diffAvgCenterLatitude >= -180) ||
-      (diffAvgCenterLatitude >= 130 && diffAvgCenterLatitude <=180)) {
+    if((diffAvgCenterLongitude <= -90 && diffAvgCenterLongitude >= -180) ||
+      (diffAvgCenterLongitude >= 90 && diffAvgCenterLongitude <=180) ||
+      (diffAvgCenterLatitude <= -90 && diffAvgCenterLatitude >= -180) ||
+      (diffAvgCenterLatitude >= 90 && diffAvgCenterLatitude <=180)) {
       atBack = true;
     }
 
@@ -1314,7 +1314,7 @@ function fadeAtEdge(d) {
       return 0;
     }
 
-    return fade(dist+0.6); // 0.6 makes the flyer visible in most parts of it,
+    return fade(dist+0.4); // 0.4 makes the flyer visible in most parts of it,
                            // without seeing the end part through the globe
                            // (if the end part is at the back of the globe).
                            // This value can also be changed as desired.


### PR DESCRIPTION
Fix to issue #22 (_Far away flyers fade a lot, making them difficult to be seen_).

- A value of 1.7 radians has been declared as the minimum distance for a flyer to be "long", and according to that, change its fading at a different rate than "short" flyers.

- "Long" flyers fade according to `fade(dist+0.6)`, where 0.6 is an approximate value for the flyer to be visible.

Any of these values can be modified as desired, so that the fading can be controlled.