### PR TITLE
Fix globe rotation

### DIFF
--- a/pairviewer.js
+++ b/pairviewer.js
@@ -1281,11 +1281,13 @@ function rotateToPoint(p) {
   d3.transition()
     .duration(1000)
     .tween("rotate", function () {
-      let r = d3.geoInterpolate(proj.rotate(), [-parseInt(q[0]), -parseInt(q[1]), proj.rotate()[2]]);
+      let r = d3.geoInterpolate(proj.rotate(), [-parseInt(q[0]), -parseInt(q[1])]);
       return function (t) {
-        proj.rotate(r(t));
-        sky.rotate(r(t));
-        space.rotate([-r(t)[0], -r(t)[1], r(t)[2]])
+        let s = r(t);
+        s.push(proj.rotate()[2]);
+        proj.rotate(s);
+        sky.rotate(s);
+        space.rotate([-s[0], -s[1], s[2]])
         o0 = proj.rotate();
         refresh();
       };

--- a/pairviewer.js
+++ b/pairviewer.js
@@ -1281,7 +1281,7 @@ function rotateToPoint(p) {
   d3.transition()
     .duration(1000)
     .tween("rotate", function () {
-      let r = d3.interpolate(proj.rotate(), [-parseInt(q[0]), -parseInt(q[1]), proj.rotate()[2]]);
+      let r = d3.geoInterpolate(proj.rotate(), [-parseInt(q[0]), -parseInt(q[1]), proj.rotate()[2]]);
       return function (t) {
         proj.rotate(r(t));
         sky.rotate(r(t));


### PR DESCRIPTION
Fixes #45 

What was happening was that it was interpolating believing it was just normal numbers, which meant the code didn't know that you could go from a positive coordinate to a negative one by _increasing_, as this doesn't happen with normal numbers. Thankfully, `d3-geo` has this nice `geoInterpolate` function that does exactly what we want.

From exactly the same point, to the same point, the [old behaviour](https://imgur.com/a/fVCTyEN) and the [new one](https://imgur.com/a/0H2EPuw)